### PR TITLE
Fix imsave

### DIFF
--- a/DuSC_explorer/__init__.py
+++ b/DuSC_explorer/__init__.py
@@ -10,7 +10,7 @@ from datetime import datetime
 import pyqtgraph as pg
 from pyqtgraph.graphicsItems.ROI import Handle
 import numpy as np
-from tifffile import imsave
+from tifffile import imwrite
 from numba import jit, prange
 import stempy.io as stio
 
@@ -400,18 +400,20 @@ class DuSC(QWidget):
             out_path = Path(file_name)
         else:
             return
-
+        
         # Get the data and change to float
         if action.text() == 'Export diffraction (TIF)':
             if out_path.suffix != '.tif':
                 out_path = out_path.with_suffix('.tif')
-            imsave(out_path, self.dp.reshape(self.frame_dimensions).astype(np.float32))
+            imwrite(out_path, self.dp.reshape(self.frame_dimensions).astype(np.float32))
         elif action.text() == 'Export diffraction (SMV)':
             if out_path.suffix != '.img':
                 out_path = out_path.with_suffix('.img')
             self._write_smv(out_path)
         elif action.text() == 'Export real (TIF)':
-            imsave(out_path, self.rs.reshape(self.scan_dimensions).astype(np.float32))
+            if out_path.suffix != '.tif':
+                out_path = out_path.with_suffix('.tif')
+            imwrite(out_path, self.rs.reshape(self.scan_dimensions).astype(np.float32))
         else:
             print('Export: unknown action {}'.format(action.text()))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ authors = [{name = "Peter Ercius", email="percius@lbl.gov"}]
 description = "Graphical user interface to view Dual Space Crystallography data from the 4D Camera of the Molecular Foundry."
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ['stempy>=3.0', 'pyqtgraph>=0.13', 'tifffile<=v2025.1.10', 'h5py>=2.9.0', 'numpy', 'qtpy', 'numba>=0.56', 'PyQt5']
-version = "1.1.3"
+dependencies = ['stempy>=3.0', 'pyqtgraph>=0.13', 'tifffile', 'h5py>=2.9.0', 'numpy', 'qtpy', 'numba>=0.56', 'PyQt5']
+version = "1.1.4"
 
 [project.scripts]
 DuSC_explorer = "DuSC_explorer:open_file"


### PR DESCRIPTION
This removes the limit on the `tifffile` version identified in #31 and uses `tiffifle.imwrite` instead. It also fixes a small bug where the real space image suffix was not checked for .tif.